### PR TITLE
version 2.1.0 - fixes and improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,11 +25,11 @@ where to output results of the tests
 page contains element
 * `.notContains (string: selector)`  
 page does not contains element
-* `.hasCookie (string: cookieName)`  
+* `.hasCookie (string: cookieName, boolean: expected)`  
 page has cookie
 * `.hasJsVariable (string variableName)`  
 page has JS variable
-* `.isObjVisible (string: selector)`  
+* `.isObjVisible (string: selector, boolean: expected)`  
 is object visible on the current window area
 * `.valueEqualsTo (string: selector, string: value)`  
 is value of object equaled to...  
@@ -40,6 +40,8 @@ This test can be applied to any field (`select`, `input`, `button`, `textarea`).
 * `.findObj (string: selector)`  
 moves current caret to the object by selector id  
 **NOTE:** *when you run any test after `.findObj`, caret will be returned to the root object (with which plugin was initialized) after test is done*
+* `.resetObj ()`  
+resets the object, previously found in `.findObj` method
 * `.setCookie (string: cookieName, mixed: cookieValue)`  
 sets new cookie (or updates existing) with the passed value
 * `.removeCookie (string: cookieName)`  
@@ -55,6 +57,9 @@ waits for passed milliseconds before the next test / step. It could be helpful, 
 redirects current page to another URL in order to proceed with tests  
 **NOTE 1:** *each page should include .js file of plugin in order to be initialized after DOM is loaded*  
 **NOTE 2:** *redirection to the initial page, from where tests are started, could bring unexpected results (ONLY FOR v1.*)*
+* `.fillIn (string: selector, mixed: value)`  
+Fills any object by selector with specified value
+
 
 ### Hotkeys
 
@@ -68,10 +73,12 @@ stop tests, which are already run
 run tests from the start (`goto`)
 * `CTRL + ALT + P`  
 pause / resume tests
+* `CTRL + ALT + C`  
+clean console
 
 ## Roadmap
 
-* Implementing of methods `.fillIn` (for populating of any input fields) and `.waitFor` for waiting for appearing of some objects
+* Implementing `.waitFor` method for waiting for appearing of some objects
 * Restoring tests' configurations with JSON format
 * Adding initialization options, like `step_by_step`, `break_on_error` 
 * Manage inline options on-the-fly inside UAT window
@@ -84,6 +91,8 @@ pause / resume tests
 
 ## Versions
 
+* **2.1.0**  
+Unreleased yet
 * **2.0.0**  
 Release date: *3th August, 2018*
 * **1.0.1**  

--- a/src/jquery.uat2.js
+++ b/src/jquery.uat2.js
@@ -1,9 +1,10 @@
 /**
  * @name jQuery.UAT v2
  * @summary Plugin for UAT (User Acceptance Testing) of pages
- * @author thewind <thewind05@gmail.com>
- * @version 2.0
- * @pubdate: 2018-06-19
+ * @author Dmitriy Ignatiev <thewind05@gmail.com>
+ * @version 2.1.0
+ * @pubdate 2018-06-19
+ * @updated 2019-05-24
  */
 (function($){
     $.fn.uat = function(settings){
@@ -83,13 +84,6 @@
                                     $.fn.uat.log.call(this, null, '--- redirection...');
                                     break;
                             }
-                        }
-                        break;
-
-                    case 'frameReady':
-                        if (isRedirected) {
-                            isRedirected = false;
-                            run();
                         }
                         break;
                 }
@@ -404,8 +398,6 @@
         // run only in TOP level, not in frame
         if (!isFrame) {
             init();
-        } else {
-            parent.postMessage(JSON.stringify({command: 'frameReady'}), location.href);
         }
 
         return this;


### PR DESCRIPTION
## Common updates

* strict comparisons everywhere in the code
* processing of event 'load' of iframe instead of event 'frameLoaded'
* fix of 'origin' field when sending test result back to parent (did not work with another domains)
* latest found obj from 'findObj' method is not not reset right after test, it's needed to call 'resetObj' manually
* overlay above the iframe while it is redirected to another page
* oportunity to clean console with hot key 'CTRL + ALT + C'
* introducing of settings block and first option - prevent the console from cleaning before next iteration

## Tests updates

* `hasCookie` has new parameter - `expected` **boolean**; test could be passed if expected = false and cookie does not exist
* `isObjVisible` has new parameter - `expected` **boolean**; test could be passed if expected = false and object is not visible
* `isObjVisible` also checks now css properties `display` and `visibility`
* new `resetObj` step to manually reset previously found obj in `findObj` step
* `redirectTo` step can be now labeled with any string and it will be shown in console
* `fillIn` step is implemented and allows to set value for any object, found by selector

## UI updates

* redirectionLabel for redirections (mark pages with labels)
* show currently tested page in UAT window
* show passed / failed count of tests
* oportunity to filter output with either passed of failed tests
* show count of iterations
